### PR TITLE
Add phases ( valid_model, valid_cv )

### DIFF
--- a/higu/src/notebook/011_not_use_detail_desc_lgb.py
+++ b/higu/src/notebook/011_not_use_detail_desc_lgb.py
@@ -478,7 +478,7 @@ with open(lgbm_path, "wb") as f:
 #%%
 def get_pop_items(trans_cdf):
     pop = PopularItemsoftheLastWeeks([1])
-    pop.fit(trans_cdf)
+    pop.fit(trans_cdf, logger)
     pop_items = list(pop.popular_items)
     return pop_items
 
@@ -490,7 +490,7 @@ def fill_pop_items(pred_ids: ArtIds, pop_items: ArtIds) -> ArtIds:
 
 # 人気アイテムで埋める
 val_cliped_trans_cdf = clip_transactions(
-    raw_trans_cdf, datetime_dic["X"]["valid"]["end_date"]
+    raw_trans_cdf, datetime_dic["X"]["valid_model"]["end_date"]
 )
 val_pop_items = get_pop_items(val_cliped_trans_cdf)
 test_pop_items = get_pop_items(raw_trans_cdf)


### PR DESCRIPTION
## Why
- trainでは、train_y期間の正例を全部使いたい
- early_stoppingのために、validでも、valid_y期間の正例を全部使いたい
- ただ、validとtestの条件は同じにしたい ( = y期間の正例を知らずに候補生成する )

## What
- validをvalid_model, valid_cvに分ける
- train, valid_modelには、`candidate_blocks`でBoughtItemsAtInferencePhase(make_y_cdf(trans_cdf, datetime_dic['y'][phase]['start_date'], datetime_dic['y'][phase]['end_date']))を加える
