### PR TITLE
change fe interface

### DIFF
--- a/higu/src/notebook/014_multi_target_week.py
+++ b/higu/src/notebook/014_multi_target_week.py
@@ -1,7 +1,6 @@
 #%%
-# %load_ext autoreload
-# %autoreload 2
-
+%load_ext autoreload
+%autoreload 2
 
 import matplotlib.pyplot as plt
 from asyncio import SubprocessTransport
@@ -89,12 +88,12 @@ agg_list = ["mean", "max", "min", "std", "median"]
 
 article_feature_blocks = [
     # *[SexArticleBlock("article_id")],
-    *[
-        EmbBlock("article_id", article_desc_bert_dic, "bert"),
-    ],
-    *[
-        EmbBlock("article_id", resnet18_umap_10_dic, "res18"),
-    ],
+    # *[
+    #     EmbBlock("article_id", article_desc_bert_dic, "bert"),
+    # ],
+    # *[
+    #     EmbBlock("article_id", resnet18_umap_10_dic, "res18"),
+    # ],
 ]
 
 transaction_feature_blocks = [

--- a/higu/src/notebook/998_pair_calc_by_rapids_018.py
+++ b/higu/src/notebook/998_pair_calc_by_rapids_018.py
@@ -1,0 +1,37 @@
+import cudf
+import gc
+
+
+def calc_pairs(train):
+    dt = (
+        train.groupby(["customer_id", "t_dat"])["article_id"]
+        .agg(list)
+        .rename("pair")
+        .reset_index()
+    )
+    df = train[["customer_id", "t_dat", "article_id"]].merge(
+        dt, on=["customer_id", "t_dat"], how="left"
+    )
+    del dt
+    df = cudf.from_pandas(df[["article_id", "pair"]].to_pandas().explode(column="pair"))
+
+    # df = df.loc[df['article_id']!=df['pair']].reset_index(drop=True)
+    gc.collect()
+
+    # Count how many times each pair combination happens
+    df = df.groupby(["article_id", "pair"]).size().rename("count").reset_index()
+    gc.collect()
+
+    # Sort by frequency
+    df = df.sort_values(["article_id", "count"], ascending=False).reset_index(drop=True)
+    gc.collect()
+
+    df = df.to_pandas()
+    # Pick only top1 most frequent pair
+    df["rank"] = df.groupby("article_id")["pair"].cumcount()
+    df = df.loc[df["rank"] == 0].reset_index(drop=True)
+    del df["rank"]
+    gc.collect()
+    df.to_csv(input_dir / "pair_df.csv", index=False)
+
+    return df


### PR DESCRIPTION
## Why

## What



- feのインターフェースをアップデート
    - 期間によらない特徴量は先にart_cdf, cust_cdfにmergeしておく
    - trans_cdfにmergeが必要な特徴量はblockの中で列を指定し、絞ってjoinする
    - 他の特徴量に依存がある特徴量はblock内で呼び出す
    - mergeには時間がかかるので基本的にはcudfにjoinして最後にpandasにかえす
- 男女特徴量が入った
- 候補のdrop_duplicateした
- pairの候補生成をblock化した(ただしcsvが必要)
- 最新のアイテムをとってくるCGをhead→ tailに変更した